### PR TITLE
Add node 18 engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "deploy": "cf deploy gen/mta.tar -f"
     },
     "engines": {
-        "node": "^16"
+        "node": "^16 || ^18"
     },
     "cds": {
         "features": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "deploy": "cf deploy gen/mta.tar -f"
     },
     "engines": {
-        "node": "^16 || ^18"
+        "node": "^18"
     },
     "cds": {
         "features": {


### PR DESCRIPTION
When running the wdi5 tests with the SAP Continuous Integration and Delivery service it does not work out of the box unless setting the engine to node 18. We followed this tutorial: https://developers.sap.com/tutorials/cicd-wdi5-cap.html
