### PR TITLE
use LTS version

### DIFF
--- a/app/fiori-apps.html
+++ b/app/fiori-apps.html
@@ -13,8 +13,8 @@
             };
         </script>
 
-        <script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/1.109.0/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
-        <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.109.0/resources/sap-ui-core.js" data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout" data-sap-ui-compatVersion="edge" data-sap-ui-theme="sap_horizon" data-sap-ui-frameOptions="allow" data-sap-ui-async="true"></script>
+        <script id="sap-ushell-bootstrap" src="https://sapui5.hana.ondemand.com/1.108.27/test-resources/sap/ushell/bootstrap/sandbox.js"></script>
+        <script id="sap-ui-bootstrap" src="https://sapui5.hana.ondemand.com/1.108.27/resources/sap-ui-core.js" data-sap-ui-libs="sap.m, sap.ushell, sap.collaboration, sap.ui.layout" data-sap-ui-compatVersion="edge" data-sap-ui-theme="sap_horizon" data-sap-ui-frameOptions="allow" data-sap-ui-async="true"></script>
         <script>
             sap.ui.getCore().attachInit(() => sap.ushell.Container.createRenderer().placeAt("content"));
         </script>


### PR DESCRIPTION
Version 1.109.x is out of cloud provisioning. As the Fiori Elements application changes a little bit with a UI5 version higher than 1.109, we stick to the 1.108 which has a LTS support till [Q4/2028](https://sapui5.hana.ondemand.com/versionoverview.html).